### PR TITLE
Added support for iOS 13's dark mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.theos
+packages

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: com.muirey03.cr4shed
 Name: Cr4shed
 Depends: mobilesubstrate, com.muirey03.libmryipc, com.cokepokes.libnotifications (>= 0.2-2), cy+cpu.arm64 | cy+cpu.arm64e, firmware (>= 9.0), ws.hbang.common (>= 1.11)
-Version: 4.1.2
+Version: 4.1.3
 Architecture: iphoneos-arm
 Description: A modern crash reporter for iOS
 Maintainer: Muirey03

--- a/cr4shedgui/CRALogController.m
+++ b/cr4shedgui/CRALogController.m
@@ -20,7 +20,10 @@
     if ([self.navigationItem respondsToSelector:@selector(setLargeTitleDisplayMode:)])
         self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 
-    self.view.backgroundColor = [UIColor whiteColor];
+    if (@available(iOS 13, *))
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    else
+        self.view.backgroundColor = [UIColor whiteColor];
 
     UIBarButtonItem* shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction target:self action:@selector(share:)];
     self.navigationItem.rightBarButtonItem = shareButton;
@@ -28,11 +31,14 @@
     webView = [WKWebView new];
     logMessage = _log.contents;
 
-    NSString* htmlString =  @"<html><head><title>.</title><meta name='viewport' content='initial-scale=1.0,maximum-scale=3.0'/></head><body><pre style=\"font-size:8pt;\">%@</pre></body></html>";
+    NSString *cssString = @"body { font-size:8pt; } @media (prefers-color-scheme: dark) { body { color: white; } }";
+    NSString* htmlString =  @"<html><head><title>.</title><meta name='viewport' content='initial-scale=1.0,maximum-scale=3.0'/><style>%@</style></head><body><pre>%@</pre></body></html>";
     NSString* formattedStr = [logMessage kv_encodeHTMLCharacterEntities];
-    htmlString = [NSString stringWithFormat:htmlString, formattedStr];
+    htmlString = [NSString stringWithFormat:htmlString, cssString, formattedStr];
     [self.view addSubview:webView];
 
+    webView.opaque = NO;
+    webView.backgroundColor = [UIColor clearColor];
     webView.translatesAutoresizingMaskIntoConstraints = NO;
     [webView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor].active = YES;
     [webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor].active = YES;

--- a/cr4shedgui/CRALogInfoViewController.m
+++ b/cr4shedgui/CRALogInfoViewController.m
@@ -75,7 +75,7 @@
 	if ([self.view respondsToSelector:@selector(safeAreaLayoutGuide)])
 		[footer.bottomAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.bottomAnchor].active = YES;
 	else
-		[footer.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide].active = YES;
+		[footer.bottomAnchor constraintEqualToAnchor:self.bottomLayoutGuide.bottomAnchor].active = YES;
 
 	UIButton* viewLogBtn = [UIButton buttonWithType:UIButtonTypeRoundedRect];
 	viewLogBtn.translatesAutoresizingMaskIntoConstraints = NO;

--- a/cr4shedgui/CRALogInfoViewController.m
+++ b/cr4shedgui/CRALogInfoViewController.m
@@ -64,7 +64,11 @@
 	const CGFloat btnCornerRadius = 10.;
 
 	_tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0., 0., 0., footerHeight)];
-	UIBlurEffect* blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
+	UIBlurEffect* blurEffect;
+    if (@available(iOS 13, *))
+		blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemMaterial];
+    else
+		blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
 	UIVisualEffectView* footer = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
 	[self.view addSubview:footer];
 

--- a/cr4shedgui/CRARootViewController.m
+++ b/cr4shedgui/CRARootViewController.m
@@ -17,7 +17,10 @@
 		
 		_countLbl = [[UILabel alloc] initWithFrame:CGRectZero];
 		_countLbl.font = [UIFont systemFontOfSize:15.];
-		_countLbl.textColor = [UIColor whiteColor];
+		if (@available(iOS 13, *))
+			_countLbl.textColor = [UIColor whiteColor];
+		else
+			_countLbl.textColor = [UIColor labelColor];
 		_countLbl.backgroundColor = [UIColor systemRedColor];
 		_countLbl.textAlignment = NSTextAlignmentCenter;
 		_countLbl.numberOfLines = 1;

--- a/frpreferences/FRPSliderCell.m
+++ b/frpreferences/FRPSliderCell.m
@@ -35,7 +35,10 @@
     lLabel.adjustsFontSizeToFitWidth = YES;
     lLabel.clipsToBounds = YES;
     lLabel.backgroundColor = [UIColor clearColor];
-    lLabel.textColor = [UIColor blackColor];
+    if (@available(iOS 13, *))
+        lLabel.textColor = [UIColor labelColor];
+    else
+        lLabel.textColor = [UIColor blackColor];
     lLabel.textAlignment = NSTextAlignmentCenter;
     [cell.contentView addSubview:lLabel];
     cell.lLabel = lLabel;
@@ -47,7 +50,10 @@
     rLabel.adjustsFontSizeToFitWidth = YES;
     rLabel.clipsToBounds = YES;
     rLabel.backgroundColor = [UIColor clearColor];
-    rLabel.textColor = [UIColor blackColor];
+    if (@available(iOS 13, *))
+        rLabel.textColor = [UIColor labelColor];
+    else
+        rLabel.textColor = [UIColor blackColor];
     rLabel.textAlignment = NSTextAlignmentCenter;
     [cell.contentView addSubview:rLabel];
     cell.rLabel = rLabel;
@@ -59,7 +65,10 @@
     cLabel.adjustsFontSizeToFitWidth = YES;
     cLabel.clipsToBounds = YES;
     cLabel.backgroundColor = [UIColor clearColor];
-    cLabel.textColor = [UIColor blackColor];
+    if (@available(iOS 13, *))
+        cLabel.textColor = [UIColor labelColor];
+    else
+        cLabel.textColor = [UIColor blackColor];
     cLabel.textAlignment = NSTextAlignmentLeft;
     [cell.contentView addSubview:cLabel];
     cell.cLabel = cLabel;
@@ -71,7 +80,10 @@
     vLabel.adjustsFontSizeToFitWidth = YES;
     vLabel.clipsToBounds = YES;
     vLabel.backgroundColor = [UIColor clearColor];
-    vLabel.textColor = [UIColor grayColor];
+    if (@available(iOS 13, *))
+        vLabel.textColor = [UIColor secondaryLabelColor];
+    else
+        vLabel.textColor = [UIColor grayColor];
     vLabel.textAlignment = NSTextAlignmentRight;
     [cell.contentView addSubview:vLabel];
     cell.vLabel = vLabel;


### PR DESCRIPTION
As mentioned in the title, I've added support for iOS 13's dark mode. This works flawlessly for me on my iPhone 11 Pro Max and iPad 7, both running iOS 13.3.

I also fixed a typo made when creating a constraint. A prebuilt binary can be found [here](https://github.com/jacobcxdev/Cr4shed/releases).